### PR TITLE
fix: update version to 1.0.0-M6.1 in documentation

### DIFF
--- a/src/content/docs/1.0.0-M5.1/en/models/dashScope.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/dashScope.md
@@ -31,7 +31,7 @@ description: "Spring AI Alibaba 接入 DashScope 模型"
     <dependency>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba-starter</artifactId>
-        <version>1.0.0-M5.1</version>
+        <version>1.0.0-M6.1</version>
     </dependency>
     ```
 

--- a/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
@@ -35,7 +35,7 @@ DeepSeek是一家创新型科技公司，成立于2023年7月17日，使用数�
     <dependency>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba-starter</artifactId>
-        <version>1.0.0-M6</version>
+        <version>1.0.0-M6.1</version>
     </dependency>
     ```
 

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/dashScope.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/dashScope.md
@@ -31,7 +31,7 @@ description: "Spring AI Alibaba 接入 DashScope 模型"
     <dependency>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba-starter</artifactId>
-        <version>1.0.0-M5.1</version>
+        <version>1.0.0-M6.1</version>
     </dependency>
     ```
 

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
@@ -35,7 +35,7 @@ DeepSeek是一家创新型科技公司，成立于2023年7月17日，使用数�
     <dependency>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba-starter</artifactId>
-        <version>1.0.0-M6</version>
+        <version>1.0.0-M6.1</version>
     </dependency>
     ```
 


### PR DESCRIPTION
This PR fixes **Issue #36**   
针对文档中model-deepseek下面的spring-ai-alibaba-starter依赖引用，经过核对没有文档中所说的1.0.0-M6，只存在1.0.0-M6.1