### PR TITLE
fix: Correct version to 1.0.0-M5.1

### DIFF
--- a/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
@@ -35,7 +35,7 @@ DeepSeek是一家创新型科技公司，成立于2023年7月17日，使用数�
     <dependency>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba-starter</artifactId>
-        <version>1.0.0-M6</version>
+        <version>1.0.0-M5.1</version>
     </dependency>
     ```
 

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
@@ -35,7 +35,7 @@ DeepSeek是一家创新型科技公司，成立于2023年7月17日，使用数�
     <dependency>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba-starter</artifactId>
-        <version>1.0.0-M6</version>
+        <version>1.0.0-M5.1</version>
     </dependency>
     ```
 


### PR DESCRIPTION
This PR fixes Issue https://github.com/springaialibaba/spring-ai-alibaba-website/issues/36
针对文档中model-deepseek下面的spring-ai-alibaba-starter依赖引用，错误的引用M6，修正为M5.1