### PR TITLE
fix: Modify the Spring AI (DeepSeek) sample code

### DIFF
--- a/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String deepSeek(@RequestParam String prompt) {
+        
+        return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/deepseek.md
@@ -146,7 +146,7 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String deepSeek(@RequestParam String prompt) {
+    public String simpleChat(@RequestParam String prompt) {
         
         return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }

--- a/src/content/docs/1.0.0-M5.1/en/models/like-openAI.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/like-openAI.md
@@ -50,10 +50,10 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel likeOpenAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public likeOpenAIChatModelController (ChatModel chatModel) {
+        this.likeOpenAIChatModel = chatModel;
     }
     ```
 
@@ -61,8 +61,8 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
+    public String simpleChat(@RequestParam String prompt) {
 
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+        return likeOpenAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M5.1/en/models/ollama.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/ollama.md
@@ -58,9 +58,9 @@ Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快�
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat() {
+    public String simpleChat(@RequestParam String prompt) {
 
-        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+        return ollamaChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```
 

--- a/src/content/docs/1.0.0-M5.1/en/models/openAI.md
+++ b/src/content/docs/1.0.0-M5.1/en/models/openAI.md
@@ -44,10 +44,10 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel openAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public OpenAIChatModelController (ChatModel chatModel) {
+        this.openAIChatModel = chatModel;
     }
     ```
 
@@ -57,6 +57,6 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
     @GetMapping("/simple/chat")
     public String simpleChat () {
 
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+        return openAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
     }
     ```

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String deepSeek(@RequestParam String prompt) {
+        
+        return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/deepseek.md
@@ -146,7 +146,7 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String deepSeek(@RequestParam String prompt) {
+    public String simpleChat(@RequestParam String prompt) {
         
         return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/like-openAI.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/like-openAI.md
@@ -50,10 +50,10 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel linkOpenAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public LinkOpenAIChatModelController (ChatModel chatModel) {
+        this.linkOpenAIChatModel = chatModel;
     }
     ```
 
@@ -61,8 +61,8 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
+    public String simpleChat(@RequestParam String prompt) {
 
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+        return linkOpenAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/ollama.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/ollama.md
@@ -58,9 +58,9 @@ Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快�
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat() {
-
-        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return ollamaChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```
 

--- a/src/content/docs/1.0.0-M5.1/zh-cn/models/openAI.md
+++ b/src/content/docs/1.0.0-M5.1/zh-cn/models/openAI.md
@@ -44,10 +44,10 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel openAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public OpenAIChatModelController (ChatModel chatModel) {
+        this.openAIChatModel = chatModel;
     }
     ```
 
@@ -55,8 +55,8 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return openAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M6.1/en/models/deepseek.md
+++ b/src/content/docs/1.0.0-M6.1/en/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String deepSeek(@RequestParam String prompt) {
+        
+        return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M6.1/en/models/deepseek.md
+++ b/src/content/docs/1.0.0-M6.1/en/models/deepseek.md
@@ -146,7 +146,7 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String deepSeek(@RequestParam String prompt) {
+    public String simpleChat(@RequestParam String prompt) {
         
         return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }

--- a/src/content/docs/1.0.0-M6.1/en/models/like-openAI.md
+++ b/src/content/docs/1.0.0-M6.1/en/models/like-openAI.md
@@ -50,10 +50,10 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel likeOpenAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public LikeOpenAIChatModelController (ChatModel chatModel) {
+        this.likeOpenAIChatModel = chatModel;
     }
     ```
 
@@ -61,8 +61,8 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return likeOpenAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M6.1/en/models/ollama.md
+++ b/src/content/docs/1.0.0-M6.1/en/models/ollama.md
@@ -58,9 +58,9 @@ Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快�
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat() {
-
-        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return ollamaChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```
 

--- a/src/content/docs/1.0.0-M6.1/en/models/openAI.md
+++ b/src/content/docs/1.0.0-M6.1/en/models/openAI.md
@@ -44,10 +44,10 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel openAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public OpenAiChatModelController (ChatModel chatModel) {
+        this.openAIChatModel = chatModel;
     }
     ```
 
@@ -55,8 +55,8 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return openAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M6.1/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0-M6.1/zh-cn/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String deepSeek(@RequestParam String prompt) {
+        
+        return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M6.1/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0-M6.1/zh-cn/models/deepseek.md
@@ -146,7 +146,7 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String deepSeek(@RequestParam String prompt) {
+    public String simpleChat(@RequestParam String prompt) {
         
         return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }

--- a/src/content/docs/1.0.0-M6.1/zh-cn/models/like-openAI.md
+++ b/src/content/docs/1.0.0-M6.1/zh-cn/models/like-openAI.md
@@ -50,10 +50,10 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel likeOpenAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public LikeOpenAIChatModelController (ChatModel chatModel) {
+        this.likeOpenAIChatModel = chatModel;
     }
     ```
 
@@ -61,8 +61,8 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return likeOpenAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/1.0.0-M6.1/zh-cn/models/ollama.md
+++ b/src/content/docs/1.0.0-M6.1/zh-cn/models/ollama.md
@@ -58,9 +58,9 @@ Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快�
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat() {
-
-        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return ollamaChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```
 

--- a/src/content/docs/1.0.0-M6.1/zh-cn/models/openAI.md
+++ b/src/content/docs/1.0.0-M6.1/zh-cn/models/openAI.md
@@ -44,10 +44,10 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel openAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public OpenAIChatModelController (ChatModel chatModel) {
+        this.openAIChatModel = chatModel;
     }
     ```
 
@@ -55,8 +55,8 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String simpleChat(@RequestParam String prompt) {
+        
+        return openAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/dev/en/models/deepseek.md
+++ b/src/content/docs/dev/en/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String deepSeek(@RequestParam String prompt) {
-        
+    public String simpleChat(@RequestParam String prompt) {
+
         return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/dev/en/models/deepseek.md
+++ b/src/content/docs/dev/en/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String deepSeek(@RequestParam String prompt) {
+        
+        return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```

--- a/src/content/docs/dev/en/models/like-openAI.md
+++ b/src/content/docs/dev/en/models/like-openAI.md
@@ -50,10 +50,10 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel linkOpenAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public LinkOpenAIChatModelController (ChatModel chatModel) {
+        this.linkOpenAIChatModel = chatModel;
     }
     ```
 
@@ -63,6 +63,6 @@ description: "Spring AI 接入类 OpenAI API 系列模型"
     @GetMapping("/simple/chat")
     public String simpleChat () {
 
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+        return linkOpenAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
     }
     ```

--- a/src/content/docs/dev/en/models/ollama.md
+++ b/src/content/docs/dev/en/models/ollama.md
@@ -58,9 +58,9 @@ Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快�
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat() {
+    public String simpleChat(@RequestParam String prompt) {
 
-        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+        return ollamaChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```
 

--- a/src/content/docs/dev/en/models/openAI.md
+++ b/src/content/docs/dev/en/models/openAI.md
@@ -44,10 +44,10 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
 3. 注入 ChatModel
 
     ```java
-    private final ChatModel deepSeekChatModel;
+    private final ChatModel openAIChatModel;
 
-    public DeepSeekChatModelController (ChatModel chatModel) {
-        this.deepSeekChatModel = chatModel;
+    public OpenAIChatModelController (ChatModel chatModel) {
+        this.openAIChatModel = chatModel;
     }
     ```
 
@@ -57,6 +57,6 @@ OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI 
     @GetMapping("/simple/chat")
     public String simpleChat () {
 
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+        return openAIChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
     }
     ```

--- a/src/content/docs/dev/zh-cn/models/deepseek.md
+++ b/src/content/docs/dev/zh-cn/models/deepseek.md
@@ -146,8 +146,8 @@ DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可
 
     ```java
     @GetMapping("/simple/chat")
-    public String simpleChat () {
-
-        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    public String deepSeek(@RequestParam String prompt) {
+        
+        return deepseekChatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
     }
     ```


### PR DESCRIPTION
修改 model 下的使用spring ai 接入 DeepSeek 的示例代码，原代码中prompt参数未声明，且在spring-ai-openai-spring-boot-starter 1.0.0-M6 中疑似将AssistantMessage的getContent方法移除，欲获取string内容返回，采用getText