### PR TITLE
Fix Markdown rendering issue caused by mixing <font> tags with backticks

### DIFF
--- a/src/content/docs/1.0.0-M6.1/zh-cn/practices/usecase/playground-flight-booking.md
+++ b/src/content/docs/1.0.0-M6.1/zh-cn/practices/usecase/playground-flight-booking.md
@@ -97,7 +97,7 @@ this.chatClient = modelBuilder
 				.build();
 ```
 
-<font style="color:#5e5e5e;">这样，</font>`<font style="color:#5e5e5e;">ChatClient</font>`<font style="color:#5e5e5e;">就为我们屏蔽了所有与大模型交互的细节，只需要把 </font>`<font style="color:#5e5e5e;">ChatClient</font>`<font style="color:#5e5e5e;">注入常规的 Spring Bean 就可以为我们的机票应用加入智能化能力了。</font>
+<font style="color:#5e5e5e;">这样，</font><font style="color:#5e5e5e;">ChatClient</font><font style="color:#5e5e5e;">就为我们屏蔽了所有与大模型交互的细节，只需要把 </font><font style="color:#5e5e5e;">ChatClient</font><font style="color:#5e5e5e;">注入常规的 Spring Bean 就可以为我们的机票应用加入智能化能力了。</font>
 
 最终，我们开发的示例运行效果如下所示：
 


### PR DESCRIPTION

### 问题描述：
![image](https://github.com/user-attachments/assets/4161b3f8-d35e-4ebf-8801-cd930b28efc5)

* Version  ID: 2bac3769-2613-f739-4796-0737c7cd8919
* Content: [智能机票助手](https://java2ai.com/docs/1.0.0-M6.1/practices/usecase/playground-flight-booking/)
* Content Source: https://github.com/springaialibaba/spring-ai-alibaba-website/blob/main/src/content/docs/1.0.0-M6.1/zh-cn/practices/usecase/playground-flight-booking.md
* Service: **用户指南/开发指南/运维指南**
在文档中使用了以下结构：
```html
<font style="color:#5e5e5e;">这样，</font>`<font style="color:#5e5e5e;">ChatClient</font>`<font style="color:#5e5e5e;">就……</font>
```
由于反引号是 Markdown 的语法，会将其中内容当作代码文本处理，导致：

<font> 样式失效；

内容渲染变成“部分灰色 + 部分高亮 + 样式丢失”；

渲染行为不一致（不同平台可能完全失效）。

### 建议修复方案：
去除了"`"包裹或者使用纯 Markdown 的代码块语法,如
```md
<font style="color:#5e5e5e;">这样，ChatClient 就为我们屏蔽了所有与大模型交互的细节，只需要把 ChatClient 注入常规的 Spring Bean 就可以为我们的机票应用加入智能化能力了。</font>
```