### PR TITLE
为官网文档1.0.0.2版本添加模型配置内容

### DIFF
--- a/src/content/docs/1.0.0.2/_sidebar.json
+++ b/src/content/docs/1.0.0.2/_sidebar.json
@@ -37,6 +37,17 @@
 		"collapsed": false
 	},
 	{
+        "label": "模型",
+        "translations": {
+            "en": "Models"
+        },
+        "autogenerate": {
+            "directory": "models"
+        },
+		"collapsed": true,
+        "items": []
+	},
+	{
 		"label": "使用教程",
 		"translations": {
 			"en": "Tutorials"

--- a/src/content/docs/1.0.0.2/en/models/dashScope.md
+++ b/src/content/docs/1.0.0.2/en/models/dashScope.md
@@ -1,0 +1,132 @@
+---
+title: DashScope
+keywords: [Spring AI,通义千问,百炼,DashScope]
+description: "Spring AI Alibaba 接入 DashScope 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入阿里云 DashScope 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## DashScope 平台
+
+灵积通过灵活、易用的模型 API 服务，让各种模态模型的能力，都能方便的为 AI 开发者所用。通过灵积 API，开发者不仅可以直接集成大模型的强大能力，也可以对模型进行训练微调，实现模型定制化。
+
+## Spring AI Alibaba 接入
+
+1. 引入 `spring-ai-alibaba-starter`：
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>3.3.4</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-starter</artifactId>
+        <version>1.0.0-M5.1</version>
+    </dependency>
+    ```
+
+2. 配置 application.yml：
+
+    ```yml
+    spring:
+      ai:
+        dashscope:
+          api-key: ${AI_DASHSCOPE_API_KEY}
+    ```
+
+3. 注入 ChatModel：(假设类名为 DashScopeChatModelController)
+
+    ```JAVA
+    private final ChatModel dashScopeChatModel;
+
+	public DashScopeChatModelController(ChatModel chatModel) {
+		this.dashScopeChatModel = chatModel;
+	}
+    ```
+    
+4. 编写 Controller 接口：
+
+    ```java
+    @GetMapping("/simple/chat")
+	public String simpleChat() {
+
+		return dashScopeChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+	}
+
+	/**
+	 * Stream 流式调用。可以使大模型的输出信息实现打字机效果。
+	 * @return Flux<String> types.
+	 */
+	@GetMapping("/stream/chat")
+	public Flux<String> streamChat(HttpServletResponse response) {
+
+		// 避免返回乱码
+		response.setCharacterEncoding("UTF-8");
+
+		Flux<ChatResponse> stream = dashScopeChatModel.stream(new Prompt(DEFAULT_PROMPT));
+		return stream.map(resp -> resp.getResult().getOutput().getContent());
+	}
+    ```
+
+至此，已经完成了 DashScope 的基本接入。现在您已经可以和 DashScope 模型对话了。
+
+## 进阶使用
+
+### 动态设置 DashScope Options 
+
+Spring AI Alibaba 的运行时 Options 同 Spring AI。分为 Runtime Options 和 Default Options。在 `application.yml` 中配置的 options 参数为 Default Options。
+
+优先级顺序为：`Runtime Options` > `Default Options`。
+
+既您可以在模型运行时，动态设置模型参数，包括本次请求使用的模型等参数信息。
+
+```java
+@GetMapping("/custom/chat")
+public String customChat() {
+
+    DashScopeChatOptions customOptions = DashScopeChatOptions.builder()
+            .withTopP(0.7)
+            .withTopK(50)
+            .withTemperature(0.8)
+            .withModel("xxx")
+            .build();
+
+    return dashScopeChatModel.call(new Prompt(DEFAULT_PROMPT, customOptions)).getResult().getOutput().getContent();
+}
+```
+
+### 结构化返回
+
+在模型请求中，您可以指定模型的返回格式。使模型返回您需要的数据格式。
+
+目前支持的输出格式为：`TEXT` 和 `JSON_OBJECT`。
+
+您可以通过指定以下 Options 参数实现：
+
+```java
+public XXXontroller(ChatModel chatModel) {
+
+    DashScopeResponseFormat responseFormat = new DashScopeResponseFormat();
+    responseFormat.setType(DashScopeResponseFormat.Type.JSON_OBJECT);
+
+    this.chatModel = chatModel;
+    this.dashScopeChatClient = ChatClient.builder(chatModel)
+            .defaultOptions(
+                    DashScopeChatOptions.builder()
+                            .withTopP(0.7)
+                            .withResponseFormat(responseFormat)
+                            .build()
+            )
+            .build();
+}
+```

--- a/src/content/docs/1.0.0.2/en/models/deepseek.md
+++ b/src/content/docs/1.0.0.2/en/models/deepseek.md
@@ -1,0 +1,153 @@
+---
+title: DeepSeek
+keywords: [Spring AI,DeepSeek,Spring AI Alibaba]
+description: "Spring AI 接入 DeepSeek 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入 DeepSeek 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## DeepSeek 
+
+DeepSeek是一家创新型科技公司，成立于2023年7月17日，使用数据蒸馏技术，得到更为精炼、有用的数据。 由知名私募巨头幻方量化孕育而生，专注于开发先进的大语言模型（LLM）和相关技术。
+
+其开源的第一代推理模型 DeepSeek-R1 模型，拥有卓越的性能，在数学、代码和推理任务上可与 OpenAI o1 媲美。
+
+## Spring AI Alibaba 接入
+
+在阿里云 DashScope  平台，同样提供了 DeepSeek 模型。同时 Spring AI Alibaba 也做了模型接入适配，您可以通过 `spring-ai-alibaba-starter` 接入 DeepSeek 系列模型。
+
+1. 引入 `spring-ai-alibaba-starter` 
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>3.3.4</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-starter</artifactId>
+        <version>1.0.0-M5.1</version>
+    </dependency>
+    ```
+
+2. 在 `application.yml` 文件中指定使用的模型
+
+    ```yaml
+    spring:
+      ai:
+        dashscope:
+          api-key: ${AI_DASHSCOPE_API_KEY}
+          chat:
+            options:
+              model: deepseek-r1
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final DashScopeChatModel chatModel;
+
+    public DeepSeekController(DashScopeChatModel chatModel) {
+        this.chatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller
+
+    ```java
+    @GetMapping("/{prompt}")
+	public Generation chat(@PathVariable(value = "prompt") String prompt) {
+
+		ChatResponse chatResponse = chatModel.call(new Prompt(prompt));
+
+		return chatResponse.getResult();
+	}
+    ```
+
+至此，便完成了 DashScope 平台上 DeepSeek 模型的接入。
+
+另外，Spring AI Alibaba 还支持 DeepSeek 的 Reasoning Content 透出，您可以通过以下方式获得 DeepSeek 的 Reasoning Content：
+
+```java
+@GetMapping("/{prompt}")
+public String chat(@PathVariable(value = "prompt") String prompt) {
+
+    ChatResponse chatResponse = chatModel.call(new Prompt(prompt));
+
+    if (!chatResponse.getResults().isEmpty()) {
+        Map<String, Object> metadata = chatResponse.getResults()
+                .get(0)
+                .getOutput()
+                .getMetadata();
+
+        System.out.println(metadata.get("reasoningContent"));
+    }
+
+    return chatResponse.getResult().getOutput().getContent();
+}
+```
+
+之后，您可以在控制台看到如下输出：
+
+```text
+嗯，用户发来“你好”，这是个常见的中文问候。首先，我需要确认用户的需求。可能只是打个招呼，或者想开始一段对话。接下来，我应该用友好的回应回复，同时保持开放，让用户知道可以提供帮助。需要检查有没有拼写错误，确保回复自然。另外，考虑用户可能的后续问题，比如需要信息或帮助解决问题。保持简洁，但足够亲切。使用适当的标点符号和表情符号可能会让回复更温暖，不过现在通常不用表情。还要注意语言是否符合中文习惯，避免机械化的回答。可能还需要快速生成回复，减少等待时间。总之，保持礼貌和专业的平衡，让用户感到被重视和支持。
+```
+
+## Spring AI 接入
+
+DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可以基于 `spring-ai-openai-spring-boot-starter` 接入 DeepSeek 模型。(Spring AI 当前未适配 DeepSeek Reasoning Content)
+
+1. 引入 `spring-ai-openai-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 配置 `application.yml`
+
+    ```yaml
+    spring:
+      application:
+      name: spring-ai-alibaba-deepseek-chat-model-example
+
+      ai:
+        openai:
+          api-key: ${AI_OPENAI_API_KEY}
+          base-url: ${AI_OPENAI_BASE_URL}
+          chat:
+            options:
+              model: deepseek-r1
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final ChatModel deepSeekChatModel;
+
+    public DeepSeekChatModelController (ChatModel chatModel) {
+        this.deepSeekChatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller 控制器
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat () {
+
+        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    }
+    ```

--- a/src/content/docs/1.0.0.2/en/models/like-openAI.md
+++ b/src/content/docs/1.0.0.2/en/models/like-openAI.md
@@ -1,0 +1,68 @@
+---
+title: 类 OpenAI API
+keywords: [Spring AI,OpenAI API,Spring AI Alibaba]
+description: "Spring AI 接入类 OpenAI API 系列模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入类 OpenAI API 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## 类 OpenAI API 系列模型接入
+
+类 OpenAI API 模型指的是提供了 OpenAI API 兼容的一系列大模型，例如 DashScope 服务平台模型，DeepSeek 等。
+
+## Spring AI Alibaba 接入
+
+需要在项目中接入具有 OpenAI API 规范的大模型时，只需要引入 `spring-ai-openai-spring-boot-starter` 即可。下面以 DeepSeek 为例演示如何进入具有类 OpenAI API 系列模型的接入。
+
+1. 引入 `spring-ai-openai-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 配置 `application.yml`
+
+    ```yaml
+    spring:
+      application:
+      name: spring-ai-alibaba-deepseek-chat-model-example
+
+      ai:
+        openai:
+          api-key: ${AI_OPENAI_API_KEY}
+          base-url: ${AI_OPENAI_BASE_URL}
+          chat:
+            options:
+              model: deepseek-r1
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final ChatModel deepSeekChatModel;
+
+    public DeepSeekChatModelController (ChatModel chatModel) {
+        this.deepSeekChatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller 控制器
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat () {
+
+        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    }
+    ```

--- a/src/content/docs/1.0.0.2/en/models/ollama.md
+++ b/src/content/docs/1.0.0.2/en/models/ollama.md
@@ -1,0 +1,67 @@
+---
+title: Ollama
+keywords: [Spring AI,OLlama API,Spring AI Alibaba]
+description: "Spring AI 接入 Ollama 系列模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入 Ollama 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## Ollama
+
+Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快速在本地运行大模型。通过简单的安装指令，用户可以通过一条命令轻松启动和运行开源的大型语言模型。
+
+是 LLM 领域的 Docker。
+
+## Spring AI Alibaba 接入
+
+在项目中引入在 Ollama 上部署的模型时，需要引入 `spring-ai-ollama-spring-boot-starter`。同时指定 Ollama 服务的 baseURL 以及运行的模型名称。
+
+1. 引入 `spring-ai-ollama-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-ollama-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 编写 `application.yml`
+
+    ```yaml
+    spring:
+      ai:
+        ollama:
+          base-url: http://localhost:11434
+          chat:
+            model: llama3
+    ```
+
+3. 遵循构造注入的方式注入 ChatModel
+
+    ```java
+    private final ChatModel ollamaChatModel;
+
+    public OllamaChatModelController(ChatModel chatModel) {
+        this.ollamaChatModel = chatModel;
+    }
+    ```
+
+4. 编写控制器接口
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat() {
+
+        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+    }
+    ```
+
+至此，我们便完成 Ollama 系列模型的接入。

--- a/src/content/docs/1.0.0.2/en/models/openAI.md
+++ b/src/content/docs/1.0.0.2/en/models/openAI.md
@@ -1,0 +1,62 @@
+---
+title: OpenAI
+keywords: [Spring AI,OpenAI,Spring AI Alibaba]
+description: "Spring AI 接入 OpenAI 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入OpenAI 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## OpenAI 
+
+OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI Inc，和其营利组织子公司 OpenAI LP 所组成。OpenAI 进行 AI 研究的目的是促进和发展友好的人工智能，使人类整体受益。
+
+是 GPT 系列模型的创始和发布公司。其发布的众多模型在数学，自然语言，图像等领域能力突出，推动了 AI 发展。
+
+## Spring AI Alibaba 接入
+
+1. 引入 `spring-ai-openai-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 配置 `application.yml`。（国内连接 OpenAI 时，可能会不通，需要借助代理地址访问）
+
+    ```yaml
+    spring:
+      ai:
+        openai:
+          api-key: ${OPENAI_API_KEY}
+          base-url: https://api.openai-hk.com
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final ChatModel deepSeekChatModel;
+
+    public DeepSeekChatModelController (ChatModel chatModel) {
+        this.deepSeekChatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller 控制器
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat () {
+
+        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    }
+    ```

--- a/src/content/docs/1.0.0.2/zh-cn/models/dashScope.md
+++ b/src/content/docs/1.0.0.2/zh-cn/models/dashScope.md
@@ -1,0 +1,132 @@
+---
+title: DashScope
+keywords: [Spring AI,通义千问,百炼,DashScope]
+description: "Spring AI Alibaba 接入 DashScope 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入阿里云 DashScope 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/chat-client.md)；
+2. [Chat Model](../tutorials/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## DashScope 平台
+
+灵积通过灵活、易用的模型 API 服务，让各种模态模型的能力，都能方便的为 AI 开发者所用。通过灵积 API，开发者不仅可以直接集成大模型的强大能力，也可以对模型进行训练微调，实现模型定制化。
+
+## Spring AI Alibaba 接入
+
+1. 引入 `spring-ai-alibaba-starter`：
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>3.3.4</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-starter</artifactId>
+        <version>1.0.0-M5.1</version>
+    </dependency>
+    ```
+
+2. 配置 application.yml：
+
+    ```yml
+    spring:
+      ai:
+        dashscope:
+          api-key: ${AI_DASHSCOPE_API_KEY}
+    ```
+
+3. 注入 ChatModel：(假设类名为 DashScopeChatModelController)
+
+    ```JAVA
+    private final ChatModel dashScopeChatModel;
+
+	public DashScopeChatModelController(ChatModel chatModel) {
+		this.dashScopeChatModel = chatModel;
+	}
+    ```
+    
+4. 编写 Controller 接口：
+
+    ```java
+    @GetMapping("/simple/chat")
+	public String simpleChat() {
+
+		return dashScopeChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+	}
+
+	/**
+	 * Stream 流式调用。可以使大模型的输出信息实现打字机效果。
+	 * @return Flux<String> types.
+	 */
+	@GetMapping("/stream/chat")
+	public Flux<String> streamChat(HttpServletResponse response) {
+
+		// 避免返回乱码
+		response.setCharacterEncoding("UTF-8");
+
+		Flux<ChatResponse> stream = dashScopeChatModel.stream(new Prompt(DEFAULT_PROMPT));
+		return stream.map(resp -> resp.getResult().getOutput().getContent());
+	}
+    ```
+
+至此，已经完成了 DashScope 的基本接入。现在您已经可以和 DashScope 模型对话了。
+
+## 进阶使用
+
+### 动态设置 DashScope Options 
+
+Spring AI Alibaba 的运行时 Options 同 Spring AI。分为 Runtime Options 和 Default Options。在 `application.yml` 中配置的 options 参数为 Default Options。
+
+优先级顺序为：`Runtime Options` > `Default Options`。
+
+即您可以在模型运行时，动态设置模型参数，包括本次请求使用的模型等参数信息。
+
+```java
+@GetMapping("/custom/chat")
+public String customChat() {
+
+    DashScopeChatOptions customOptions = DashScopeChatOptions.builder()
+            .withTopP(0.7)
+            .withTopK(50)
+            .withTemperature(0.8)
+            .withModel("xxx")
+            .build();
+
+    return dashScopeChatModel.call(new Prompt(DEFAULT_PROMPT, customOptions)).getResult().getOutput().getContent();
+}
+```
+
+### 结构化返回
+
+在模型请求中，您可以指定模型的返回格式。使模型返回您需要的数据格式。
+
+目前支持的输出格式为：`TEXT` 和 `JSON_OBJECT`。
+
+您可以通过指定以下 Options 参数实现：
+
+```java
+public XXXontroller(ChatModel chatModel) {
+
+    DashScopeResponseFormat responseFormat = new DashScopeResponseFormat();
+    responseFormat.setType(DashScopeResponseFormat.Type.JSON_OBJECT);
+
+    this.chatModel = chatModel;
+    this.dashScopeChatClient = ChatClient.builder(chatModel)
+            .defaultOptions(
+                    DashScopeChatOptions.builder()
+                            .withTopP(0.7)
+                            .withResponseFormat(responseFormat)
+                            .build()
+            )
+            .build();
+}
+```

--- a/src/content/docs/1.0.0.2/zh-cn/models/deepseek.md
+++ b/src/content/docs/1.0.0.2/zh-cn/models/deepseek.md
@@ -1,0 +1,153 @@
+---
+title: DeepSeek
+keywords: [Spring AI,DeepSeek,Spring AI Alibaba]
+description: "Spring AI 接入 DeepSeek 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入 DeepSeek 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## DeepSeek 
+
+DeepSeek是一家创新型科技公司，成立于2023年7月17日，使用数据蒸馏技术，得到更为精炼、有用的数据。 由知名私募巨头幻方量化孕育而生，专注于开发先进的大语言模型（LLM）和相关技术。
+
+其开源的第一代推理模型 DeepSeek-R1 模型，拥有卓越的性能，在数学、代码和推理任务上可与 OpenAI o1 媲美。
+
+## Spring AI Alibaba 接入
+
+在阿里云 DashScope  平台，同样提供了 DeepSeek 模型。同时 Spring AI Alibaba 也做了模型接入适配，您可以通过 `spring-ai-alibaba-starter` 接入 DeepSeek 系列模型。
+
+1. 引入 `spring-ai-alibaba-starter` 
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>3.3.4</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-starter</artifactId>
+        <version>1.0.0-M5.1</version>
+    </dependency>
+    ```
+
+2. 在 `application.yml` 文件中指定使用的模型
+
+    ```yaml
+    spring:
+      ai:
+        dashscope:
+          api-key: ${AI_DASHSCOPE_API_KEY}
+          chat:
+            options:
+              model: deepseek-r1
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final DashScopeChatModel chatModel;
+
+    public DeepSeekController(DashScopeChatModel chatModel) {
+        this.chatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller
+
+    ```java
+    @GetMapping("/{prompt}")
+	public Generation chat(@PathVariable(value = "prompt") String prompt) {
+
+		ChatResponse chatResponse = chatModel.call(new Prompt(prompt));
+
+		return chatResponse.getResult();
+	}
+    ```
+
+至此，便完成了 DashScope 平台上 DeepSeek 模型的接入。
+
+另外，Spring AI Alibaba 还支持 DeepSeek 的 Reasoning Content 透出，您可以通过以下方式获得 DeepSeek 的 Reasoning Content：
+
+```java
+@GetMapping("/{prompt}")
+public String chat(@PathVariable(value = "prompt") String prompt) {
+
+    ChatResponse chatResponse = chatModel.call(new Prompt(prompt));
+
+    if (!chatResponse.getResults().isEmpty()) {
+        Map<String, Object> metadata = chatResponse.getResults()
+                .get(0)
+                .getOutput()
+                .getMetadata();
+
+        System.out.println(metadata.get("reasoningContent"));
+    }
+
+    return chatResponse.getResult().getOutput().getContent();
+}
+```
+
+之后，您可以在控制台看到如下输出：
+
+```text
+嗯，用户发来“你好”，这是个常见的中文问候。首先，我需要确认用户的需求。可能只是打个招呼，或者想开始一段对话。接下来，我应该用友好的回应回复，同时保持开放，让用户知道可以提供帮助。需要检查有没有拼写错误，确保回复自然。另外，考虑用户可能的后续问题，比如需要信息或帮助解决问题。保持简洁，但足够亲切。使用适当的标点符号和表情符号可能会让回复更温暖，不过现在通常不用表情。还要注意语言是否符合中文习惯，避免机械化的回答。可能还需要快速生成回复，减少等待时间。总之，保持礼貌和专业的平衡，让用户感到被重视和支持。
+```
+
+## Spring AI 接入
+
+DeepSeek 模型提供了兼容 OpenAI API 的 API 接口实现，因此我们可以基于 `spring-ai-openai-spring-boot-starter` 接入 DeepSeek 模型。(Spring AI 当前未适配 DeepSeek Reasoning Content)
+
+1. 引入 `spring-ai-openai-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 配置 `application.yml`
+
+    ```yaml
+    spring:
+      application:
+      name: spring-ai-alibaba-deepseek-chat-model-example
+
+      ai:
+        openai:
+          api-key: ${AI_OPENAI_API_KEY}
+          base-url: ${AI_OPENAI_BASE_URL}
+          chat:
+            options:
+              model: deepseek-r1
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final ChatModel deepSeekChatModel;
+
+    public DeepSeekChatModelController (ChatModel chatModel) {
+        this.deepSeekChatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller 控制器
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat () {
+
+        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    }
+    ```

--- a/src/content/docs/1.0.0.2/zh-cn/models/like-openAI.md
+++ b/src/content/docs/1.0.0.2/zh-cn/models/like-openAI.md
@@ -1,0 +1,68 @@
+---
+title: 类 OpenAI API
+keywords: [Spring AI,OpenAI API,Spring AI Alibaba]
+description: "Spring AI 接入类 OpenAI API 系列模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入类 OpenAI API 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## 类 OpenAI API 系列模型接入
+
+类 OpenAI API 模型指的是提供了 OpenAI API 兼容的一系列大模型，例如 DashScope 服务平台模型，DeepSeek 等。
+
+## Spring AI Alibaba 接入
+
+需要在项目中接入具有 OpenAI API 规范的大模型时，只需要引入 `spring-ai-openai-spring-boot-starter` 即可。下面以 DeepSeek 为例演示如何进入具有类 OpenAI API 系列模型的接入。
+
+1. 引入 `spring-ai-openai-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 配置 `application.yml`
+
+    ```yaml
+    spring:
+      application:
+      name: spring-ai-alibaba-deepseek-chat-model-example
+
+      ai:
+        openai:
+          api-key: ${AI_OPENAI_API_KEY}
+          base-url: ${AI_OPENAI_BASE_URL}
+          chat:
+            options:
+              model: deepseek-r1
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final ChatModel deepSeekChatModel;
+
+    public DeepSeekChatModelController (ChatModel chatModel) {
+        this.deepSeekChatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller 控制器
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat () {
+
+        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    }
+    ```

--- a/src/content/docs/1.0.0.2/zh-cn/models/ollama.md
+++ b/src/content/docs/1.0.0.2/zh-cn/models/ollama.md
@@ -1,0 +1,67 @@
+---
+title: Ollama
+keywords: [Spring AI,OLlama API,Spring AI Alibaba]
+description: "Spring AI 接入 Ollama 系列模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入 Ollama 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## Ollama
+
+Ollama 是一个开源的大型语言模型服务工具，旨在帮助用户快速在本地运行大模型。通过简单的安装指令，用户可以通过一条命令轻松启动和运行开源的大型语言模型。
+
+是 LLM 领域的 Docker。
+
+## Spring AI Alibaba 接入
+
+在项目中引入在 Ollama 上部署的模型时，需要引入 `spring-ai-ollama-spring-boot-starter`。同时指定 Ollama 服务的 baseURL 以及运行的模型名称。
+
+1. 引入 `spring-ai-ollama-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-ollama-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 编写 `application.yml`
+
+    ```yaml
+    spring:
+      ai:
+        ollama:
+          base-url: http://localhost:11434
+          chat:
+            model: llama3
+    ```
+
+3. 遵循构造注入的方式注入 ChatModel
+
+    ```java
+    private final ChatModel ollamaChatModel;
+
+    public OllamaChatModelController(ChatModel chatModel) {
+        this.ollamaChatModel = chatModel;
+    }
+    ```
+
+4. 编写控制器接口
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat() {
+
+        return ollamaChatModel.call(new Prompt(DEFAULT_PROMPT)).getResult().getOutput().getContent();
+    }
+    ```
+
+至此，我们便完成 Ollama 系列模型的接入。

--- a/src/content/docs/1.0.0.2/zh-cn/models/openAI.md
+++ b/src/content/docs/1.0.0.2/zh-cn/models/openAI.md
@@ -1,0 +1,62 @@
+---
+title: OpenAI
+keywords: [Spring AI,OpenAI,Spring AI Alibaba]
+description: "Spring AI 接入 OpenAI 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入OpenAI 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/basics/chat-client.md)；
+2. [Chat Model](../tutorials/basics/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example) 仓库找到。
+
+> 本示例主要演示如何以 ChatModel 形式接入。关于如何使用 ChatClient，请参考 Github 代码仓库示例。
+
+## OpenAI 
+
+OpenAI，是一个美国人工智能研究实验室，由非营利组织 OpenAI Inc，和其营利组织子公司 OpenAI LP 所组成。OpenAI 进行 AI 研究的目的是促进和发展友好的人工智能，使人类整体受益。
+
+是 GPT 系列模型的创始和发布公司。其发布的众多模型在数学，自然语言，图像等领域能力突出，推动了 AI 发展。
+
+## Spring AI Alibaba 接入
+
+1. 引入 `spring-ai-openai-spring-boot-starter`
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>1.0.0-M6</version>
+    </dependency>
+    ```
+
+2. 配置 `application.yml`。（国内连接 OpenAI 时，可能会不通，需要借助代理地址访问）
+
+    ```yaml
+    spring:
+      ai:
+        openai:
+          api-key: ${OPENAI_API_KEY}
+          base-url: https://api.openai-hk.com
+    ```
+
+3. 注入 ChatModel
+
+    ```java
+    private final ChatModel deepSeekChatModel;
+
+    public DeepSeekChatModelController (ChatModel chatModel) {
+        this.deepSeekChatModel = chatModel;
+    }
+    ```
+
+4. 编写 Controller 控制器
+
+    ```java
+    @GetMapping("/simple/chat")
+    public String simpleChat () {
+
+        return deepSeekChatModel.call(new Prompt(prompt)).getResult().getOutput().getContent();
+    }
+    ```

--- a/src/content/docs/1.0.0.2/zh-cn/models/qwq.md
+++ b/src/content/docs/1.0.0.2/zh-cn/models/qwq.md
@@ -1,0 +1,285 @@
+---
+title: QWQ 32B
+keywords: [Spring AI,通义千问,百炼,DashScope, QWQ 32B]
+description: "Spring AI Alibaba 接入 QWQ 32B 模型"
+---
+
+在本章节中，我们将学习如何使用 Spring AI Alibaba 接入阿里云 QWQ 32B 系列模型。在开始学习之前，请确保您已经了解相关概念。
+
+1. [Chat Client](../tutorials/chat-client.md)；
+2. [Chat Model](../tutorials/chat-model.md)；
+3. [Spring AI Alibaba 快速开始](../get-started.md)；
+4. 本章节的代码您可以在 [Spring AI Alibaba Example](https://github.com/springaialibaba/spring-ai-alibaba-examples/tree/main/spring-ai-alibaba-chat-example/qwq-chat) 中找到。
+
+> 本示例主要演示如何以 ChatClient 形式接入。关于如何使用 ChatModel，请参阅其他模型的 ChatModel 代码示例。
+
+## QWQ 32B
+
+基于 Qwen2.5 模型训练的 QwQ 推理模型，通过强化学习大幅度提升了模型推理能力。模型数学代码等核心指标（AIME 24/25、LiveCodeBench）以及部分通用指标（IFEval、LiveBench等）达到DeepSeek-R1 满血版水平。相较于开源版，商业版具有最新的能力和改进。
+
+## Spring AI Alibaba 接入
+
+1. 引入 `spring-ai-alibaba-starter`：
+
+    ```xml
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>3.3.4</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-starter</artifactId>
+        <version>1.0.0-M6.1</version>
+    </dependency>
+    ```
+
+2. 配置 application.yml：
+
+    ```yml
+    server:
+      port: 10002
+
+    spring:
+      application:
+        name: spring-ai-alibaba-qwq-chat-client-example
+
+      ai:
+        dashscope:
+	  api-key: ${AI_DASHSCOPE_API_KEY}
+
+	  chat:
+	    options:
+	      model: qwq-plus
+    ```
+
+
+3. 注入 ChatClient (假设类名为 QWQChatClientController)
+
+    ```JAVA
+	public QWQChatClientController(ChatModel chatModel) {
+
+		this.chatModel = chatModel;
+
+		// 构造时，可以设置 ChatClient 的参数
+		// {@link org.springframework.ai.chat.client.ChatClient};
+		this.chatClient = ChatClient.builder(chatModel)
+				// 实现 Chat Memory 的 Advisor
+				// 在使用 Chat Memory 时，需要指定对话 ID，以便 Spring AI 处理上下文。
+				.defaultAdvisors(
+						new MessageChatMemoryAdvisor(new InMemoryChatMemory()),
+				)
+				// 实现 Logger 的 Advisor
+				.defaultAdvisors(
+						new SimpleLoggerAdvisor()
+				)
+				// 设置 ChatClient 中 ChatModel 的 Options 参数
+				.defaultOptions(
+						DashScopeChatOptions.builder()
+								.withTopP(0.7)
+								.build()
+				)
+				.build();
+	}
+    ```
+    
+4. 编写 Controller 接口：
+
+    ```java
+	@GetMapping("/stream/chat")
+	public Flux<String> streamChat(HttpServletResponse response) {
+
+		response.setCharacterEncoding("UTF-8");
+
+		return chatClient.prompt(DEFAULT_PROMPT)
+				.stream()
+				.content();
+	}
+    ```
+
+至此，已经完成了 QWQ 32B 模型的基本接入。现在您已经可以和 QWQ 32B 模型对话了。
+
+## 获取 QWQ 32B 模型的思考输出
+
+> Spring AI Alibaba 1.0.0-M6.1 版本支持获取 DeepSeek-r1 和 QWQ 32B 模型的思维链。
+
+### 编写 ReasoningContentAdvisor
+
+```java
+public class ReasoningContentAdvisor implements BaseAdvisor {
+
+	private static final Logger logger = LoggerFactory.getLogger(ReasoningContentAdvisor.class);
+
+	private final int order;
+
+	public ReasoningContentAdvisor(Integer order) {
+		this.order = order != null ? order : 0;
+	}
+
+	@NotNull
+	@Override
+	public AdvisedRequest before(@NotNull AdvisedRequest request) {
+
+		return request;
+	}
+
+	@NotNull
+	@Override
+	public AdvisedResponse after(AdvisedResponse advisedResponse) {
+
+		ChatResponse resp = advisedResponse.response();
+		if (Objects.isNull(resp)) {
+
+			return advisedResponse;
+		}
+
+		logger.debug(String.valueOf(resp.getResults().get(0).getOutput().getMetadata()));
+		String reasoningContent = String.valueOf(resp.getResults().get(0).getOutput().getMetadata().get("reasoningContent"));
+
+		if (StringUtils.hasText(reasoningContent)) {
+			List<Generation> thinkGenerations = resp.getResults().stream()
+					.map(generation -> {
+						AssistantMessage output = generation.getOutput();
+						AssistantMessage thinkAssistantMessage = new AssistantMessage(
+									String.format("<think>%s</think>", reasoningContent) + output.getText(),
+								output.getMetadata(),
+								output.getToolCalls(),
+								output.getMedia()
+						);
+						return new Generation(thinkAssistantMessage, generation.getMetadata());
+					}).toList();
+
+			ChatResponse thinkChatResp = ChatResponse.builder().from(resp).generations(thinkGenerations).build();
+			return AdvisedResponse.from(advisedResponse).response(thinkChatResp).build();
+
+		}
+
+		return advisedResponse;
+	}
+
+	@Override
+	public int getOrder() {
+
+		return this.order;
+	}
+
+}
+```
+
+### 注入 ReasoningContentAdvisor
+
+```java
+public QWQChatClientController(ChatModel chatModel) {
+
+    this.chatModel = chatModel;
+
+    // ...
+            .defaultAdvisors(
+                    new MessageChatMemoryAdvisor(new InMemoryChatMemory()),
+
+                    // 整合 QWQ 的思考过程到输出中
+                    new ReasoningContentAdvisor(0)
+            )
+            // ...
+}
+```
+
+### 请求接口查看输出
+
+```shell
+$ curl http://localhost:10002/qwq/chat-client/stream/chat
+
+<think>好的，用户让我</think>
+<think>介绍自己，我之前</think>
+<think>已经回答过一次了</think>
+<think>，现在又问</think>
+<think>同样的问题。用户</think>
+<think>可能是想再确认一下</think>
+<think>我的功能，或者需要</think>
+<think>更详细的介绍？</think>
+<think>也有可能他们想</think>
+<think>测试我的一致性hink>
+<think>又全面，同时保持简洁</think>
+<think>。首先，回顾之前的回答</think>
+<think>，已经涵盖了基本</think>
+<think>功能、支持的语言、应用场景</think>
+<think>。这次可能需要添加</think>
+<think>一些信息，比如</think>
+<think>最近的更新或者</think>
+<think>更多例子，让用户</think>
+<think>觉得有新内容</think>
+<think>。不过根据指示</think>
+<think>，不能编造新</think>
+<think>功能，所以只能</think>
+<think>在原有基础上调整</think>
+<think>结构或补充细节。</think>
+<think>用户可能希望了解我的应用场景</think>
+<think>，或者想确认</think>
+<think>我的能力是否符合他们的</think>
+<think>需求。需要强调</think>
+<think>我的多语能力和</think>
+<think>具体应用实例，比如编程</think>
+<think>、逻辑推理等。</think>
+<think>另外，可以加入</think>
+<think>一些鼓励用户提问的</think> >
+<think>语句，促进进一步互动</think>
+<think>。检查是否有需要</think>
+<think>避免的内容，比如不</think>
+<think>提及未实现的功能。</think>
+<think>确保语气友好，使用</think>
+<think>表情符号增加亲切</think>
+<think>。最后，保持回答自然</think>
+<think>流畅，避免重复之前的</think>
+<think>结构，但信息</think>
+<think>要准确一致。</think>
+
+你好！我是是义千问（Qwen），阿里巴巴集团旗下的超大规模语言模型。我能够帮助你完成各种任务，比如：
+
+- **回答问题**：无论是常识、专业知识，还是复杂问题，我都会尽力为你解答。
+- **创作文字**：写故事、公文、邮件、剧本、诗歌等，我都可以尝试。
+- **逻辑与编程**：解决数学问题、编写代码、进行逻辑推理。
+- **多语言支持**：除了中文，我还支持英文、德语、法语、西班牙语等多种语言。
+- **表达观点与互动**：聊日常话题、玩游戏，甚至讨论观点。
+
+我的目标是成为一位全能的AI助手，无论你需要学习、工作还是娱乐上的帮助，我都会用友好且实用的方式回应你。有什么需要我帮忙的吗？😊
+```
+
+## 注意事项
+
+QWQ 32B 目前仍有许多限制，在开发时需要注意：
+
+1. 模型调用方式
+
+QWQ 模型目前只支持 Stream 调用。如果使用非 Stream 调用时会出现如下错误：
+
+400 - {"code":"InvalidParameter","message":"This model only support stream mode, please enable the stream parameter to access the model."}
+
+2. QWQ 模型的其他限制
+
+2.1 不支持功能
+
+    - 工具调用（Function Call）
+    - 结构化输出（JSON Mode）
+    - 前缀续写（Partial Mode）
+    - 上下文缓存（Context Cache）
+
+2.2 不支持的参数
+
+    - temperature
+    - top_p
+    - presence_penalty
+    - frequency_penalty
+    - logprobs
+    - top_logprobs
+
+设置这些参数都不会生效，即使没有输出错误提示。
+
+3. System Message
+
+为了达到模型的最佳推理效果，不建议设置 System Message。
+
+## 参考文档：
+
+- QWQ 32B 模型文档：https://help.aliyun.com/zh/model-studio/getting-started/models
+- 错误码文档：https://help.aliyun.com/zh/model-studio/developer-reference/error-code


### PR DESCRIPTION

模型配置内容在1.0.0-M6.1已有，但1.0.0.2的版本文档缺少这部分，添加过去即可
https://java2ai.com/docs/1.0.0-M6.1/models/dashScope/?spm=5176.29160081.0.0.2856aa5cSon96O
issue地址【https://github.com/alibaba/spring-ai-alibaba/issues/1745#issue-3250783020】