### PR TITLE
fix: fix broken links and relative path references

### DIFF
--- a/agents-docs/assistantagent/quick-start.md
+++ b/agents-docs/assistantagent/quick-start.md
@@ -76,7 +76,7 @@ mvn spring-boot:run
 
 ![Agent Chat UI](/img/chatui/agent-chat-ui.gif)
 
-> 项目默认集成了 [Spring AI Alibaba Studio](../../docs/frameworks/studio/quick-start.md)，提供开箱即用的可视化对话界面。
+> 项目默认集成了 [Spring AI Alibaba Studio](/docs/frameworks/studio/quick-start)，提供开箱即用的可视化对话界面。
 
 ### 方式二：API 集成
 

--- a/docs/frameworks/agent-framework/tutorials/tools.md
+++ b/docs/frameworks/agent-framework/tutorials/tools.md
@@ -14,7 +14,7 @@ Tools 是 [agents](./agents.md) 调用来执行操作的组件。它们通过定
 >
 > 某些聊天模型（例如 OpenAI、Anthropic 和 Gemini）具有在服务器端执行的内置工具，如 Web 搜索和代码解释器。请参阅提供商概述以了解如何使用特定聊天模型访问这些工具。
 
-> **TIP:** 遵循指南从已弃用的 [FunctionCallback 迁移到 ToolCallback API](../../../integration/toolcalls/tools-migration.md)。
+> **TIP:** 迁移与更多 Tool Calling 说明请参考：[Tool Calling 使用指南](/integration/toolcalls/tool-calls)。
 
 _Tool calling_（也称为 _function calling_）是 AI 应用程序中的常见模式，允许 model 与一组 API 或 _tools_ 交互，增强其能力。
 
@@ -926,9 +926,9 @@ ToolCallbackResolver toolCallbackResolver(List<ToolCallback> toolCallbacks) {
 
 ## 可观测性
 
-Tool calling 包括可观测性支持，使用 spring.ai.tool 观察来测量完成时间并传播跟踪信息。请参阅 [Tool Calling 可观测性](../../../integration/observability/index.md#tool-calling)。
+Tool calling 包括可观测性支持，使用 spring.ai.tool 观察来测量完成时间并传播跟踪信息。请参阅 [Tool Calling 可观测性](https://docs.spring.io/spring-ai/reference/observability/index.html#_tool_calling)。
 
-可选地，Spring AI 可以将 tool call 参数和结果导出为 span 属性，默认情况下出于敏感性原因禁用。详细信息：[Tool Call 参数和结果数据](../../../integration/observability/index.md#tool-call-arguments-and-result-data)。
+可选地，Spring AI 可以将 tool call 参数和结果导出为 span 属性，默认情况下出于敏感性原因禁用。详细信息：[Tool Call 参数和结果数据](https://docs.spring.io/spring-ai/reference/observability/index.html#_tool_call_arguments_and_result_data)。
 
 ### 日志记录
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -28,8 +28,8 @@ const config: Config = {
   // check links and markdown links
   // if the link is broken, it will throw an error during build
   // if the markdown link is broken, it will show a warning during build
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
 
   // Metadata for SEO
   headTags: [

--- a/integration/chatmodels/dashScope.md
+++ b/integration/chatmodels/dashScope.md
@@ -49,9 +49,9 @@ String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI Alibaba artifacts 发布在 Maven Central 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI Alibaba 提供了 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI Alibaba。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI Alibaba 提供了 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI Alibaba。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -65,7 +65,7 @@ Spring AI Alibaba 为 DashScope Chat Client 提供 Spring Boot auto-configuratio
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -346,7 +346,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 接下来，创建一个 `DashScopeChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/deepseek-chat.md
+++ b/integration/chatmodels/deepseek-chat.md
@@ -45,9 +45,9 @@ String apiKey = System.getenv("DEEPSEEK_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Spring Milestone 和 Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -69,7 +69,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -295,7 +295,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `DeepSeekChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/gemini-chat.md
+++ b/integration/chatmodels/gemini-chat.md
@@ -46,7 +46,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -259,7 +259,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `VertexAiGeminiChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/azure-openai-chat.md
+++ b/integration/chatmodels/more/azure-openai-chat.md
@@ -117,9 +117,9 @@ Azure OpenAI 和 OpenAI 的不同部署结构导致 Azure OpenAI 客户端库中
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -143,7 +143,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 Azure OpenAI Chat Client 使用 Azure SDK 提供的 [OpenAIClientBuilder](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIClientBuilder.java) 创建。Spring AI 允许通过提供 [AzureOpenAIClientBuilderCustomizer](https://github.com/spring-projects/spring-ai/blob/main/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAIClientBuilderCustomizer.java) beans 来自定义构建器。
 
@@ -382,7 +382,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 > **提示：** `spring-ai-azure-openai` 依赖项还提供对 `AzureOpenAiChatModel` 的访问。有关 `AzureOpenAiChatModel` 的更多信息，请参阅 [Azure OpenAI Chat](../chat/azure-openai-chat.html) 部分。
 

--- a/integration/chatmodels/more/bedrock-converse.md
+++ b/integration/chatmodels/more/bedrock-converse.md
@@ -48,7 +48,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 

--- a/integration/chatmodels/more/dmr-chat.md
+++ b/integration/chatmodels/more/dmr-chat.md
@@ -53,7 +53,7 @@ Spring AI 为 OpenAI Chat Client 提供 Spring Boot auto-configuration。
 ```
 
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 

--- a/integration/chatmodels/more/google-genai-chat.md
+++ b/integration/chatmodels/more/google-genai-chat.md
@@ -55,7 +55,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -284,7 +284,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `GoogleGenAiChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/groq-chat.md
+++ b/integration/chatmodels/more/groq-chat.md
@@ -65,9 +65,9 @@ String model = System.getenv("GROQ_MODEL");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -91,7 +91,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -309,7 +309,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `OpenAiChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/huggingface.md
+++ b/integration/chatmodels/more/huggingface.md
@@ -54,9 +54,9 @@ String endpointUrl = System.getenv("HUGGINGFACE_ENDPOINT_URL");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -82,7 +82,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -159,7 +159,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `HuggingfaceChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/minimax-chat.md
+++ b/integration/chatmodels/more/minimax-chat.md
@@ -41,9 +41,9 @@ String apiKey = System.getenv("MINIMAX_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -69,7 +69,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -217,7 +217,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `MiniMaxChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/mistralai-chat.md
+++ b/integration/chatmodels/more/mistralai-chat.md
@@ -44,9 +44,9 @@ String apiKey = System.getenv("MISTRALAI_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -72,7 +72,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -289,7 +289,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `MistralAiChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/nvidia-chat.md
+++ b/integration/chatmodels/more/nvidia-chat.md
@@ -43,7 +43,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 

--- a/integration/chatmodels/more/oci-genai/cohere-chat.md
+++ b/integration/chatmodels/more/oci-genai/cohere-chat.md
@@ -11,9 +11,9 @@
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -39,7 +39,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -173,7 +173,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `OCICohereChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/openai-sdk-chat.md
+++ b/integration/chatmodels/more/openai-sdk-chat.md
@@ -91,9 +91,9 @@ spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -113,7 +113,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Configuration Properties
 
@@ -512,7 +512,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `OpenAiSdkChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/more/perplexity-chat.md
+++ b/integration/chatmodels/more/perplexity-chat.md
@@ -74,9 +74,9 @@ String completionsPath = System.getenv("PERPLEXITY_COMPLETIONS_PATH");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -100,7 +100,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 

--- a/integration/chatmodels/more/zhipuai-chat.md
+++ b/integration/chatmodels/more/zhipuai-chat.md
@@ -43,9 +43,9 @@ String apiKey = System.getenv("ZHIPUAI_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -71,7 +71,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -221,7 +221,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `ZhiPuAiChatModel` 并将其用于文本生成：
 

--- a/integration/chatmodels/ollama-chat.md
+++ b/integration/chatmodels/ollama-chat.md
@@ -49,7 +49,7 @@ Spring AI 为 Ollama chat 集成提供 Spring Boot auto-configuration。
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Base Properties
 
@@ -604,7 +604,7 @@ public class ChatController {
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 > **提示：** `spring-ai-ollama` 依赖项还提供对 `OllamaEmbeddingModel` 的访问。
 > 有关 `OllamaEmbeddingModel` 的更多信息，请参阅 [Ollama Embedding Model](../embeddings/ollama-embeddings.html) 部分。

--- a/integration/chatmodels/openai-chat.md
+++ b/integration/chatmodels/openai-chat.md
@@ -46,9 +46,9 @@ String apiKey = System.getenv("OPENAI_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统中。
 
-为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
+为了帮助进行依赖管理，Spring AI 提供了一个 BOM (bill of materials)，以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统中。
 
 ## Auto-configuration
 
@@ -66,7 +66,7 @@ Spring AI 为 OpenAI Chat Client 提供 Spring Boot auto-configuration。
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Chat Properties
 
@@ -526,7 +526,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `OpenAiChatModel` 并将其用于文本生成：
 

--- a/integration/multimodals/audio/speech.md
+++ b/integration/multimodals/audio/speech.md
@@ -5,7 +5,7 @@ Spring AI 通过 `TextToSpeechModel` 和 `StreamingTextToSpeechModel` 接口为 
 ## Supported Providers
 
 - [OpenAI's Speech API](speech/openai-speech.md)
-- [Eleven Labs Text-To-Speech API](speech/elevenlabs-speech.md)
+<!-- - [Eleven Labs Text-To-Speech API](speech/elevenlabs-speech.md) -->
 - [DashScope Text-To-Speech API](speech/dashscope-speech.md)
 
 ## Common Interface

--- a/integration/multimodals/audio/speech/dashscope-speech.md
+++ b/integration/multimodals/audio/speech/dashscope-speech.md
@@ -37,7 +37,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 ## Speech Properties
 
@@ -139,7 +139,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 接下来，创建一个 `DashScopeAudioSpeechModel`：
 

--- a/integration/multimodals/audio/speech/openai-speech.md
+++ b/integration/multimodals/audio/speech/openai-speech.md
@@ -11,7 +11,7 @@ Audio API 提供基于 OpenAI 的 TTS (text-to-speech) 模型的语音端点，�
 ## Prerequisites
 
 1. 创建 OpenAI 账户并获取 API key。您可以在 [OpenAI signup page](https://platform.openai.com/signup) 注册，并在 [API Keys page](https://platform.openai.com/account/api-keys) 生成 API key。
-2. 将 `spring-ai-openai` 依赖项添加到项目的构建文件中。有关更多信息，请参考 [Dependency Management](getting-started.md#dependency-management) 部分。
+2. 将 `spring-ai-openai` 依赖项添加到项目的构建文件中。有关更多信息，请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分。
 
 ## Auto-configuration
 
@@ -38,7 +38,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ## Speech Properties
 
@@ -128,7 +128,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `OpenAiAudioSpeechModel`：
 

--- a/integration/multimodals/audio/transcriptions.md
+++ b/integration/multimodals/audio/transcriptions.md
@@ -5,7 +5,7 @@ Spring AI 通过 `TranscriptionModel` 接口为 Speech-to-Text 转录提供统�
 ## Supported Providers
 
 - [OpenAI's Whisper API](transcriptions/openai-transcriptions.md)
-- [Azure OpenAI Whisper API](transcriptions/azure-openai-transcriptions.md)
+<!-- - [Azure OpenAI Whisper API](transcriptions/azure-openai-transcriptions.md) -->
 - [DashScope Transcription API](transcriptions/dashscope-transcriptions.md)
 
 ## Common Interface

--- a/integration/multimodals/audio/transcriptions/dashscope-transcriptions.md
+++ b/integration/multimodals/audio/transcriptions/dashscope-transcriptions.md
@@ -36,7 +36,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 ### Transcription Properties
 
@@ -141,7 +141,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 接下来，创建一个 `DashScopeAudioTranscriptionModel`
 

--- a/integration/multimodals/audio/transcriptions/openai-transcriptions.md
+++ b/integration/multimodals/audio/transcriptions/openai-transcriptions.md
@@ -34,7 +34,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Transcription Properties
 
@@ -125,7 +125,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 接下来，创建一个 `OpenAiAudioTranscriptionModel`
 

--- a/integration/multimodals/image/azure-openai-image.md
+++ b/integration/multimodals/image/azure-openai-image.md
@@ -73,9 +73,9 @@ Azure OpenAI 和 OpenAI 的不同部署结构导致 Azure OpenAI 客户端库中
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 存储库中。
-请参考 [Artifact Repositories](getting-started.md#artifact-repositories) 部分，将这些存储库添加到您的构建系统。
+请参考 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些存储库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单）以确保在整个项目中使用一致版本的 Spring AI。请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单）以确保在整个项目中使用一致版本的 Spring AI。请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## Auto-configuration
 
@@ -102,7 +102,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Image Generation Properties
 

--- a/integration/multimodals/image/dashscope-image.md
+++ b/integration/multimodals/image/dashscope-image.md
@@ -58,7 +58,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 ### Image Generation Properties
 
@@ -180,7 +180,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件中。
 
 接下来，创建一个 `DashScopeImageModel`：
 

--- a/integration/multimodals/image/imageclient.md
+++ b/integration/multimodals/image/imageclient.md
@@ -1,6 +1,6 @@
 # Image Model API
 
-`Spring Image Model API` 旨在为与各种专门用于图像生成的 [AI Models](concepts.md#_models) 交互提供一个简单且可移植的接口，允许开发者在不同的图像相关模型之间切换，只需最少的代码更改。
+`Spring Image Model API` 旨在为与各种专门用于图像生成的 [AI Models](https://docs.spring.io/spring-ai/reference/concepts.html#models) 交互提供一个简单且可移植的接口，允许开发者在不同的图像相关模型之间切换，只需最少的代码更改。
 此设计符合 Spring 的模块化和可互换性理念，确保开发者能够快速调整应用程序以适应不同的图像处理相关 AI 能力。
 
 此外，通过 `ImagePrompt` 用于输入封装和 `ImageResponse` 用于输出处理等配套类的支持，Image Model API 统一了与专门用于图像生成的 AI Models 的通信。

--- a/integration/multimodals/image/openai-image.md
+++ b/integration/multimodals/image/openai-image.md
@@ -63,7 +63,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Image Generation Properties
 

--- a/integration/multimodals/image/openai-sdk-image.md
+++ b/integration/multimodals/image/openai-sdk-image.md
@@ -93,9 +93,9 @@ spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 存储库中。
-请参考 [Artifact Repositories](getting-started.md#artifact-repositories) 部分，将这些存储库添加到您的构建系统。
+请参考 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些存储库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单）以确保在整个项目中使用一致版本的 Spring AI。请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单）以确保在整个项目中使用一致版本的 Spring AI。请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## Auto-configuration
 
@@ -119,7 +119,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Configuration Properties
 
@@ -271,10 +271,10 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 > **NOTE**: `spring-ai-openai-sdk` 依赖项还提供对 `OpenAiSdkChatModel` 和 `OpenAiSdkEmbeddingModel` 的访问。
-> 有关 `OpenAiSdkChatModel` 的更多信息，请参阅 [OpenAI SDK Chat](openai-sdk-chat.md) 部分。
+> 有关 `OpenAiSdkChatModel` 的更多信息，请参阅 [OpenAI SDK Chat](../../chatmodels/more/openai-sdk-chat.md) 部分。
 
 接下来，创建一个 `OpenAiSdkImageModel` 实例并使用它生成图像：
 

--- a/integration/multimodals/image/stabilityai-image.md
+++ b/integration/multimodals/image/stabilityai-image.md
@@ -61,7 +61,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Image Generation Properties
 

--- a/integration/multimodals/image/zhipuai-image.md
+++ b/integration/multimodals/image/zhipuai-image.md
@@ -41,9 +41,9 @@ String apiKey = System.getenv("ZHIPUAI_API_KEY");
 ### Add Repositories and BOM
 
 Spring AI artifacts 发布在 Maven Central 和 Spring Snapshot 存储库中。
-请参考 [Artifact Repositories](getting-started.md#artifact-repositories) 部分，将这些存储库添加到您的构建系统。
+请参考 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些存储库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单）以确保在整个项目中使用一致版本的 Spring AI。请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单）以确保在整个项目中使用一致版本的 Spring AI。请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## Auto-configuration
 
@@ -70,7 +70,7 @@ dependencies {
 }
 ```
 
-> **TIP**: 请参考 [Dependency Management](getting-started.md#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **TIP**: 请参考 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Image Generation Properties
 

--- a/integration/rag/embeddings/dashscope-embeddings.md
+++ b/integration/rag/embeddings/dashscope-embeddings.md
@@ -43,9 +43,9 @@ String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
 ### 添加仓库和 BOM
 
 Spring AI Alibaba 工件发布在 Maven Central 仓库中。
-请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI Alibaba 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI Alibaba。请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI Alibaba 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI Alibaba。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -67,7 +67,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -200,10 +200,10 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI Alibaba BOM 添加到您的构建文件。
 
 注意：`spring-ai-alibaba-dashscope` 依赖项还提供对 `DashScopeChatModel` 的访问。
-有关 `DashScopeChatModel` 的更多信息，请参阅 [DashScope Chat Client](../chatmodels/dashScope.md) 部分。
+有关 `DashScopeChatModel` 的更多信息，请参阅 [DashScope Chat Client](../../chatmodels/dashScope.md) 部分。
 
 接下来，创建一个 `DashScopeEmbeddingModel` 实例并使用它来计算两个输入文本之间的相似性：
 

--- a/integration/rag/embeddings/google-genai-embeddings-text.md
+++ b/integration/rag/embeddings/google-genai-embeddings-text.md
@@ -40,9 +40,9 @@ gcloud auth application-default login <ACCOUNT>
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -70,7 +70,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -178,7 +178,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 `GoogleGenAiTextEmbeddingModel` 并将其用于文本 embeddings：
 

--- a/integration/rag/embeddings/more/azure-openai-embeddings.md
+++ b/integration/rag/embeddings/more/azure-openai-embeddings.md
@@ -93,9 +93,9 @@ NOTE: It is no longer necessary to create a `TokenCredential` bean; it is config
 ### Add Repositories and BOM
 
 Spring AI artifacts are published in Maven Central and Spring Snapshot repositories.
-Refer to the [Artifact Repositories](getting-started.adoc#artifact-repositories) section to add these repositories to your build system.
+Refer to the [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) section to add these repositories to your build system.
 
-To help with dependency management, Spring AI provides a BOM (bill of materials) to ensure that a consistent version of Spring AI is used throughout the entire project. Refer to the [Dependency Management](getting-started.adoc#dependency-management) section to add the Spring AI BOM to your build system.
+To help with dependency management, Spring AI provides a BOM (bill of materials) to ensure that a consistent version of Spring AI is used throughout the entire project. Refer to the [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) section to add the Spring AI BOM to your build system.
 
 
 ## Auto-configuration
@@ -123,7 +123,7 @@ dependencies {
 }
 ```
 
-TIP: Refer to the [Dependency Management](getting-started.adoc#dependency-management) section to add the Spring AI BOM to your build file.
+TIP: Refer to the [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) section to add the Spring AI BOM to your build file.
 
 ### Embedding Properties
 
@@ -216,7 +216,7 @@ For this add the `spring-ai-azure-openai` dependency to your project's Maven `po
 </dependency>
 ```
 
-TIP: Refer to the [Dependency Management](getting-started.adoc#dependency-management) section to add the Spring AI BOM to your build file.
+TIP: Refer to the [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) section to add the Spring AI BOM to your build file.
 
 NOTE: The `spring-ai-azure-openai` dependency also provide the access to the `AzureOpenAiEmbeddingModel`. For more information about the `AzureOpenAiChatModel` refer to the [Azure OpenAI Embeddings](../embeddings/azure-openai-embeddings.html) section.
 

--- a/integration/rag/embeddings/more/bedrock-cohere-embedding.md
+++ b/integration/rag/embeddings/more/bedrock-cohere-embedding.md
@@ -12,9 +12,9 @@ https://aws.amazon.com/bedrock/cohere-command-embed/[AWS Bedrock Cohere Model Pa
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -41,7 +41,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### 启用 Cohere Embedding 支持
 
@@ -192,7 +192,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java[BedrockCohereEmbeddingModel] 并将其用于文本 embeddings：
 

--- a/integration/rag/embeddings/more/bedrock-titan-embedding.md
+++ b/integration/rag/embeddings/more/bedrock-titan-embedding.md
@@ -18,9 +18,9 @@ https://aws.amazon.com/bedrock/titan/[AWS Bedrock Titan Model Page] 和 https://
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -47,7 +47,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### 启用 Titan Embedding 支持
 
@@ -189,7 +189,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java[BedrockTitanEmbeddingModel] 并将其用于文本 embeddings：
 

--- a/integration/rag/embeddings/more/minimax-embeddings.md
+++ b/integration/rag/embeddings/more/minimax-embeddings.md
@@ -41,9 +41,9 @@ String apiKey = System.getenv("MINIMAX_API_KEY");
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -71,7 +71,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -196,7 +196,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 注意：`spring-ai-minimax` 依赖项还提供对 `MiniMaxChatModel` 的访问。
 有关 `MiniMaxChatModel` 的更多信息，请参阅 [MiniMax Chat Client](../chat/minimax-chat.html) 部分。

--- a/integration/rag/embeddings/more/mistralai-embeddings.md
+++ b/integration/rag/embeddings/more/mistralai-embeddings.md
@@ -56,9 +56,9 @@ String apiKey = System.getenv("MISTRALAI_API_KEY");
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -86,7 +86,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -221,7 +221,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 注意：`spring-ai-mistral-ai` 依赖项还提供对 `MistralAiChatModel` 的访问。
 有关 `MistralAiChatModel` 的更多信息，请参阅 [MistralAI Chat Client](../chat/mistralai-chat.html) 部分。

--- a/integration/rag/embeddings/more/oci-genai-embeddings.md
+++ b/integration/rag/embeddings/more/oci-genai-embeddings.md
@@ -9,9 +9,9 @@ https://docs.oracle.com/en-us/iaas/Content/generative-ai/embed-models.htm[OCI Em
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -39,7 +39,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -150,7 +150,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 `OCIEmbeddingModel` 实例并使用它来计算两个输入文本之间的相似性：
 

--- a/integration/rag/embeddings/more/onnx.md
+++ b/integration/rag/embeddings/more/onnx.md
@@ -53,8 +53,8 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
 要配置它，请使用 `spring.ai.embedding.transformer.*` 属性。
 
@@ -150,7 +150,7 @@ spring.ai.embedding.transformer.onnx.modelOutputName=token_embeddings
 </dependency>
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 然后创建一个新的 `TransformersEmbeddingModel` 实例，并使用 `setTokenizerResource(tokenizerJsonUri)` 和 `setModelResource(modelOnnxUri)` 方法设置导出的 `tokenizer.json` 和 `model.onnx` 文件的 URI。（支持 `classpath:`、`file:` 或 `https:` URI 模式）。
 

--- a/integration/rag/embeddings/more/openai-sdk-embeddings.md
+++ b/integration/rag/embeddings/more/openai-sdk-embeddings.md
@@ -94,9 +94,9 @@ spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -123,7 +123,7 @@ dependencies {
 ```
 ======
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### 配置属性
 
@@ -257,7 +257,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 注意：`spring-ai-openai-sdk` 依赖项还提供对 `OpenAiSdkChatModel` 和 `OpenAiSdkImageModel` 的访问。
 有关 `OpenAiSdkChatModel` 的更多信息，请参阅 [OpenAI SDK Chat](chat/openai-sdk-chat.adoc) 部分。

--- a/integration/rag/embeddings/more/postgresml-embeddings.md
+++ b/integration/rag/embeddings/more/postgresml-embeddings.md
@@ -12,9 +12,9 @@ Embeddings 可用于通过使用距离度量比较数值向量的相似性来查
 ## 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -42,7 +42,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 使用 `spring.ai.postgresml.embedding.options.*` 属性来配置您的 `PostgresMlEmbeddingModel`。
 
@@ -144,7 +144,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 `PostgresMlEmbeddingModel` 实例并使用它来计算两个输入文本之间的相似性：
 

--- a/integration/rag/embeddings/more/zhipuai-embeddings.md
+++ b/integration/rag/embeddings/more/zhipuai-embeddings.md
@@ -43,9 +43,9 @@ String apiKey = System.getenv("ZHIPUAI_API_KEY");
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -73,7 +73,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -199,7 +199,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 注意：`spring-ai-zhipuai` 依赖项还提供对 `ZhiPuAiChatModel` 的访问。
 有关 `ZhiPuAiChatModel` 的更多信息，请参阅 [ZhiPuAI Chat Client](../chat/zhipuai-chat.html) 部分。

--- a/integration/rag/embeddings/ollama-embeddings.md
+++ b/integration/rag/embeddings/ollama-embeddings.md
@@ -60,7 +60,7 @@ dependencies {
 ```
 ======
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
 请参阅 Repositories 部分，将这些仓库添加到您的构建系统。
 
@@ -289,7 +289,7 @@ dependencies {
 ```
 ======
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 注意：`spring-ai-ollama` 依赖项还提供对 `OllamaChatModel` 的访问。
 有关 `OllamaChatModel` 的更多信息，请参阅 link:../chat/ollama-chat.html[Ollama Chat Client] 部分。

--- a/integration/rag/embeddings/openai-embeddings.md
+++ b/integration/rag/embeddings/openai-embeddings.md
@@ -43,9 +43,9 @@ String apiKey = System.getenv("OPENAI_API_KEY");
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -73,7 +73,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -210,7 +210,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 注意：`spring-ai-openai` 依赖项还提供对 `OpenAiChatModel` 的访问。
 有关 `OpenAiChatModel` 的更多信息，请参阅 [OpenAI Chat Client](../chat/openai-chat.html) 部分。

--- a/integration/rag/embeddings/vertexai-embeddings-multimodal.md
+++ b/integration/rag/embeddings/vertexai-embeddings-multimodal.md
@@ -29,9 +29,9 @@ gcloud auth application-default login <ACCOUNT>
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -59,7 +59,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -115,7 +115,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 `VertexAiMultimodalEmbeddingModel` 并将其用于 embeddings 生成：
 

--- a/integration/rag/embeddings/vertexai-embeddings-text.md
+++ b/integration/rag/embeddings/vertexai-embeddings-text.md
@@ -21,9 +21,9 @@ gcloud auth application-default login <ACCOUNT>
 ### 添加仓库和 BOM
 
 Spring AI 工件发布在 Maven Central 和 Spring Snapshot 仓库中。
-请参阅 [Artifact Repositories](getting-started.adoc#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
+请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将这些仓库添加到您的构建系统。
 
-为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
+为了帮助依赖管理，Spring AI 提供了一个 BOM（物料清单），以确保在整个项目中使用一致版本的 Spring AI。请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建系统。
 
 ## 自动配置
 
@@ -51,7 +51,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 ### Embedding 属性
 
@@ -141,7 +141,7 @@ dependencies {
 }
 ```
 
-提示：请参阅 [Dependency Management](getting-started.adoc#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
+提示：请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件。
 
 接下来，创建一个 `VertexAiTextEmbeddingModel` 并将其用于文本生成：
 

--- a/integration/rag/vectordbs/analyticdb.md
+++ b/integration/rag/vectordbs/analyticdb.md
@@ -64,8 +64,8 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
-> 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 要连接和配置 `AnalyticDbVectorStore`，您需要提供实例的访问详细信息。
 可以通过 Spring Boot 的 `application.yml` 提供简单配置：
@@ -184,7 +184,7 @@ vectorStore.similaritySearch(SearchRequest.builder()
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 要在应用程序中配置 AnalyticDB，您可以使用以下设置：
 

--- a/integration/rag/vectordbs/elasticsearch.md
+++ b/integration/rag/vectordbs/elasticsearch.md
@@ -59,9 +59,9 @@ dependencies {
 > }
 > ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 或者，您可以选择退出初始化，并使用 Elasticsearch 客户端手动创建索引，如果索引需要高级映射或额外配置，这可能很有用。

--- a/integration/rag/vectordbs/milvus.md
+++ b/integration/rag/vectordbs/milvus.md
@@ -32,8 +32,8 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
-> 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 
@@ -95,7 +95,7 @@ List<Document> results = this.vectorStore.similaritySearch(SearchRequest.builder
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 要在应用程序中配置 MilvusVectorStore，您可以使用以下设置：
 

--- a/integration/rag/vectordbs/mongodb.md
+++ b/integration/rag/vectordbs/mongodb.md
@@ -42,9 +42,9 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在 `application.properties` 文件中设置 `spring.ai.vectorstore.mongodb.initialize-schema=true` 来选择加入。
 或者，您可以选择退出初始化，并使用 MongoDB Atlas UI、Atlas Administration API 或 Atlas CLI 手动创建索引，如果索引需要高级映射或额外配置，这可能很有用。

--- a/integration/rag/vectordbs/more/apache-cassandra.md
+++ b/integration/rag/vectordbs/more/apache-cassandra.md
@@ -56,7 +56,7 @@ b. 对于托管产品，[Astra DB](https://astra.datastax.com/) 提供健康的�
 > Spring AI auto-configuration、starter modules 的 artifact 名称发生了重大变化。
 > 请参阅 [upgrade notes](https://docs.spring.io/spring-ai/reference/upgrade-notes.html) 了解更多信息。
 
-> **提示：** 对于依赖管理，我们建议使用 Spring AI BOM，如 [Dependency Management](getting-started#dependency-management) 部分所述。
+> **提示：** 对于依赖管理，我们建议使用 Spring AI BOM，如 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分所述。
 
 将这些依赖项添加到您的项目：
 

--- a/integration/rag/vectordbs/more/azure.md
+++ b/integration/rag/vectordbs/more/azure.md
@@ -82,7 +82,7 @@ export OPENAI_API_KEY=<My Azure AI API Key> (Optional)
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ## Configuration Properties
 

--- a/integration/rag/vectordbs/more/chroma.md
+++ b/integration/rag/vectordbs/more/chroma.md
@@ -39,9 +39,9 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 
@@ -222,7 +222,7 @@ author in ['john', 'jill'] && article_type == 'blog'
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Sample Code
 

--- a/integration/rag/vectordbs/more/couchbase.md
+++ b/integration/rag/vectordbs/more/couchbase.md
@@ -39,9 +39,9 @@ dependencies {
 
 > **注意：** Couchbase Vector search 仅在起始版本 7.6 和 Java SDK 版本 3.6.0 中可用
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Milestone 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Milestone 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以使用默认选项为您初始化配置的 bucket、scope、collection 和搜索索引，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值来选择加入。
 

--- a/integration/rag/vectordbs/more/mariadb.md
+++ b/integration/rag/vectordbs/more/mariadb.md
@@ -37,7 +37,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 
@@ -55,7 +55,7 @@ dependencies {
 </dependency>
 ```
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 现在您可以在应用程序中自动装配 `MariaDBVectorStore`：
 
@@ -135,7 +135,7 @@ spring:
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 然后使用构建器模式创建 `MariaDBVectorStore` bean：
 

--- a/integration/rag/vectordbs/more/pinecone.md
+++ b/integration/rag/vectordbs/more/pinecone.md
@@ -45,9 +45,9 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 此外，您需要一个配置的 `EmbeddingModel` bean。请参阅 [EmbeddingModel](embeddings#available-implementations) 部分了解更多信息。
 
@@ -161,7 +161,7 @@ vectorStore.similaritySearch(SearchRequest.builder()
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ### Sample Code
 

--- a/integration/rag/vectordbs/more/qdrant.md
+++ b/integration/rag/vectordbs/more/qdrant.md
@@ -36,11 +36,11 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 请查看 [configuration parameters](#qdrant-vectorstore-properties) 列表以了解向量存储的默认值和配置选项。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在构建器中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 
@@ -115,7 +115,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 创建 Qdrant 客户端 bean：
 

--- a/integration/rag/vectordbs/more/tablestore.md
+++ b/integration/rag/vectordbs/more/tablestore.md
@@ -40,9 +40,9 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 请查看 [configuration parameters](#tablestore-properties) 列表以了解向量存储的默认值和配置选项。
 

--- a/integration/rag/vectordbs/more/typesense.md
+++ b/integration/rag/vectordbs/more/typesense.md
@@ -35,11 +35,11 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 请查看 [configuration parameters](#_configuration_properties) 列表以了解向量存储的默认值和配置选项。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 
@@ -115,7 +115,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 创建 Typesense `Client` bean：
 

--- a/integration/rag/vectordbs/neo4j.md
+++ b/integration/rag/vectordbs/neo4j.md
@@ -44,11 +44,11 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 请查看 [Configuration Properties](#neo4jvector-properties) 列表以了解向量存储的默认值和配置选项。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 
@@ -141,7 +141,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 创建 Neo4j `Driver` bean。
 阅读 [Neo4j Documentation](https://neo4j.com/docs/java-manual/current/client-applications/) 以获取有关自定义驱动程序配置的更多深入信息。

--- a/integration/rag/vectordbs/oceanbase.md
+++ b/integration/rag/vectordbs/oceanbase.md
@@ -62,8 +62,8 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
-> 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 要连接和配置 `OceanBaseVectorStore`，您需要提供实例的访问详细信息。
 可以通过 Spring Boot 的 `application.yml` 提供简单配置：
@@ -166,7 +166,7 @@ vectorStore.similaritySearch(SearchRequest.builder()
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 要在应用程序中配置 OceanBase，您可以使用以下设置：
 

--- a/integration/rag/vectordbs/oracle.md
+++ b/integration/rag/vectordbs/oracle.md
@@ -51,8 +51,8 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
-> 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 要连接和配置 `OracleVectorStore`，您需要提供数据库的访问详细信息。
 可以通过 Spring Boot 的 `application.yml` 提供简单配置：
@@ -160,7 +160,7 @@ vectorStore.similaritySearch(SearchRequest.builder()
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 要在应用程序中配置 `OracleVectorStore`，您可以使用以下设置：
 

--- a/integration/rag/vectordbs/pgvector.md
+++ b/integration/rag/vectordbs/pgvector.md
@@ -81,8 +81,8 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
-> 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 要连接和配置 `PgVectorStore`，您需要提供实例的访问详细信息。
 可以通过 Spring Boot 的 `application.yml` 提供简单配置：
@@ -198,7 +198,7 @@ vectorStore.similaritySearch(SearchRequest.builder()
 </dependency>
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 要在应用程序中配置 PgVector，您可以使用以下设置：
 

--- a/integration/rag/vectordbs/redis.md
+++ b/integration/rag/vectordbs/redis.md
@@ -43,9 +43,9 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 向量存储实现可以为您初始化所需的 schema，但您必须通过在适当的构造函数中指定 `initializeSchema` 布尔值或在 `application.properties` 文件中设置 `...initialize-schema=true` 来选择加入。
 

--- a/integration/rag/vectordbs/tair.md
+++ b/integration/rag/vectordbs/tair.md
@@ -36,9 +36,9 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 请查看 [configuration parameters](#tair-properties) 列表以了解向量存储的默认值和配置选项。
 

--- a/integration/rag/vectordbs/weaviate.md
+++ b/integration/rag/vectordbs/weaviate.md
@@ -35,7 +35,7 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 ## Configuration
 
@@ -108,11 +108,11 @@ dependencies {
 }
 ```
 
-> **提示：** 请参阅 [Dependency Management](getting-started#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
+> **提示：** 请参阅 [Dependency Management](https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management) 部分，将 Spring AI BOM 添加到您的构建文件中。
 
 请查看 [configuration parameters](#_weaviatevectorstore_properties) 列表以了解向量存储的默认值和配置选项。
 
-> **提示：** 请参阅 [Artifact Repositories](getting-started#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
+> **提示：** 请参阅 [Artifact Repositories](https://docs.spring.io/spring-ai/reference/getting-started.html#artifact-repositories) 部分，将 Maven Central 和/或 Snapshot Repositories 添加到您的构建文件中。
 
 此外，您需要一个配置的 `EmbeddingModel` bean。
 请参阅 [EmbeddingModel](embeddings#available-implementations) 部分了解更多信息。

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,6 @@
     "node_modules/@algolia/client-search": {
       "version": "5.37.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.37.0",
         "@algolia/requester-browser-xhr": "5.37.0",
@@ -283,7 +282,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1882,7 +1880,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1903,7 +1900,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2003,7 +1999,6 @@
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2366,7 +2361,6 @@
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3256,7 +3250,6 @@
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.8.1",
         "@docusaurus/logger": "3.8.1",
@@ -4643,7 +4636,6 @@
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4924,7 +4916,6 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5427,7 +5418,6 @@
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.1.14.tgz",
       "integrity": "sha512-ukd93VGzaNPMAUPy0gRDSC57UuQbnH9Kussp7HBjM06YFi9uZTFhOvMSO2OKqXm1rSgzOE+pVx1k1PYHGwlc8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5583,7 +5573,6 @@
       "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.1",
         "@typescript-eslint/types": "8.44.1",
@@ -5936,7 +5925,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5992,7 +5980,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6047,7 +6034,6 @@
     "node_modules/algoliasearch": {
       "version": "5.37.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.3.0",
         "@algolia/client-abtesting": "5.37.0",
@@ -6596,7 +6582,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -6836,7 +6821,6 @@
     "node_modules/chevrotain": {
       "version": "11.0.3",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -7427,7 +7411,6 @@
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7713,7 +7696,6 @@
     "node_modules/cytoscape": {
       "version": "3.33.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8053,7 +8035,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8802,7 +8783,6 @@
       "version": "9.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14519,7 +14499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15327,7 +15306,6 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16047,7 +16025,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16058,7 +16035,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16105,7 +16081,6 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16130,7 +16105,6 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -16880,7 +16854,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18046,7 +18019,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18537,7 +18509,6 @@
     "node_modules/webpack": {
       "version": "5.101.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",


### PR DESCRIPTION
### Fixes: https://github.com/alibaba/spring-ai-alibaba/issues/4012

### Changes:
1. Change "link" check level from warn to critical
    ```typescript
    onBrokenLinks: 'throw',
    onBrokenMarkdownLinks: 'throw',
    ```
2. Run build to find and fix all the broken links
    change 70+ files
    a. Dependency Management -> getting-started.md#dependency-management 之类无法定位具体文档且根据描述符合 spring ai的路径 指向了 https://docs.spring.io/spring-ai/reference/getting-started.html#dependency-management
    b. 相对路径写错了（层级不对）：比如 dashscope-embeddings.md 从rag/embeddings目录跳到 chatmodels，…少写了一层。
    c. 对于2个实在找不到具体文档和对应文档的链接采用了注释的方式移除  Eleven Labs Text-To-Speech API 和Azure OpenAI Whisper API

### Screenshots of the change:
Documentation link fix only, no visual changes.