### PR TITLE
Fix A11Y: Add aria-hidden to decorative SVG elements

### DIFF
--- a/src/components/EcosystemShowcase/index.tsx
+++ b/src/components/EcosystemShowcase/index.tsx
@@ -129,7 +129,7 @@ function EcosystemCard({ item }: EcosystemCardProps): React.JSX.Element {
         <div className={styles.cardLinks}>
           {item.docUrl && (
             <Link to={item.docUrl} className={styles.cardLink}>
-              <svg className={styles.docIcon} viewBox="0 0 24 24" fill="currentColor">
+              <svg className={styles.docIcon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
               </svg>
               <Translate id="ecosystem.viewDocs">查看文档</Translate>
@@ -145,7 +145,8 @@ function EcosystemCard({ item }: EcosystemCardProps): React.JSX.Element {
               <svg
                 className={styles.githubIcon}
                 viewBox="0 0 16 16"
-                fill="currentColor">
+                fill="currentColor"
+                aria-hidden="true">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
               </svg>
               <Translate id="ecosystem.viewOnGithub">View on GitHub</Translate>

--- a/src/components/PineconeFloatingSearch/index.tsx
+++ b/src/components/PineconeFloatingSearch/index.tsx
@@ -124,7 +124,7 @@ const PineconeFloatingSearch: React.FC = () => {
   }
 
   return (
-    <div className={styles.floatingSearchContainer}>
+    <div className={styles.floatingSearchContainer} role="search">
       <button
         ref={buttonRef}
         className={clsx(styles.floatingButton, {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -139,19 +139,19 @@ function HomepageHeader() {
 
             <div className={styles.heroLabels}>
               <span className={styles.label}>
-                <svg className={styles.labelIcon} viewBox="0 0 24 24" fill="currentColor">
+                <svg className={styles.labelIcon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M20,2H4C2.9,2,2,2.9,2,4v16c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2z M8.5,15L8.5,15 c-0.83,0-1.5-0.67-1.5-1.5v-3C7,9.67,7.67,9,8.5,9l0,0C9.33,9,10,9.67,10,10.5v3C10,14.33,9.33,15,8.5,15z M15.5,15L15.5,15 c-0.83,0-1.5-0.67-1.5-1.5v-3c0-0.83,0.67-1.5,1.5-1.5l0,0c0.83,0,1.5,0.67,1.5,1.5v3C17,14.33,16.33,15,15.5,15z"/>
                 </svg>
                 Context Engineering
               </span>
               <span className={styles.label}>
-                <svg className={styles.labelIcon} viewBox="0 0 24 24" fill="currentColor">
+                <svg className={styles.labelIcon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"/>
                 </svg>
                 Multi-agent
               </span>
               <span className={styles.label}>
-                <svg className={styles.labelIcon} viewBox="0 0 24 24" fill="currentColor">
+                <svg className={styles.labelIcon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4M11,17V16H9V14H13V13H10A1,1 0 0,1 9,12V10A1,1 0 0,1 10,9H14V10H12V11H14V12H15V14A1,1 0 0,1 14,15H10V16H13V17H11Z"/>
                 </svg>
                 Workflow
@@ -162,7 +162,7 @@ function HomepageHeader() {
               <Link
                 className={clsx('button button--primary button--lg', styles.heroButton)}
                 to="/docs/quick-start">
-                <svg className={styles.buttonIcon} viewBox="0 0 24 24" fill="currentColor">
+                <svg className={styles.buttonIcon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M9,4V20H15V4H9M4,8V16H6V8H4M18,8V16H20V8H18Z" />
                 </svg>
                 &nbsp; <Translate id="homepage.quickStart" description="Quick Start button text">快速开始</Translate>
@@ -170,7 +170,7 @@ function HomepageHeader() {
               <Link
                 className={clsx('button button--primary button--lg', styles.heroButton)}
                 to={githubUrls.repo}>
-                <svg style={{ width: '1.2em', height: '1.2em', marginRight: '0.5em', verticalAlign: 'middle' }} viewBox="0 0 16 16" fill="currentColor">
+                <svg style={{ width: '1.2em', height: '1.2em', marginRight: '0.5em', verticalAlign: 'middle' }} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                   <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
                 </svg>
                 <Translate id="homepage.viewOnGithub" description="View on GitHub button text">GitHub</Translate>
@@ -245,7 +245,7 @@ function AcknowledgmentsSection() {
               <Translate id="homepage.acknowledgments.viewOnGithub" description="View on GitHub">
                 访问 GitHub
               </Translate>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                 <path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.707 9.293a1 1 0 01-1.414 1.414L9 9.414V13a1 1 0 11-2 0V9.414L5.707 10.707a1 1 0 01-1.414-1.414l3-3a1 1 0 011.414 0l3 3z"/>
               </svg>
             </a>
@@ -278,7 +278,7 @@ function AcknowledgmentsSection() {
               <Translate id="homepage.acknowledgments.learnMore" description="Learn more">
                 了解更多
               </Translate>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                 <path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.707 9.293a1 1 0 01-1.414 1.414L9 9.414V13a1 1 0 11-2 0V9.414L5.707 10.707a1 1 0 01-1.414-1.414l3-3a1 1 0 011.414 0l3 3z"/>
               </svg>
             </a>


### PR DESCRIPTION
### Fixes: #[Add issue number here]

This PR improves accessibility by adding `aria-hidden="true"` to all decorative SVG icons throughout the application. This prevents screen readers from unnecessarily announcing these visual-only elements to users with visual impairments.

The accessibility checker identified 24 violations where SVG elements lacked accessible names. These SVGs are purely decorative (icons accompanying text labels) and should not be exposed to assistive technologies.
<img width="2560" height="919" alt="image" src="https://github.com/user-attachments/assets/644a926e-d21a-481b-9d11-fb507ec83d11" />

### Changes:

Added `aria-hidden="true"` attribute to all decorative SVG elements in the following files:

Files Changed
```
src/components/EcosystemShowcase/index.tsx
src/components/PineconeFloatingSearch/index.tsx
src/pages/index.tsx
```

### Screenshots of the change:

**Fix Before:**
<img width="2560" height="920" alt="image" src="https://github.com/user-attachments/assets/4feeb0ff-606e-48ad-a4e9-923981962b7c" />
24 violations where SVG elements lacked accessible names.

**Fix After:**
<img width="2560" height="920" alt="image" src="https://github.com/user-attachments/assets/39cc3840-2a09-40bd-a654-56337083d520" />
All svg violations have been resolved.

### Accessibility Impact
This change improves the experience for users relying on screen readers by:

- Reducing unnecessary verbosity when navigating the interface
- Focusing attention on meaningful content rather than decorative elements
- Following WCAG guidelines for proper semantic markup


The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.