### PR TITLE
Fixes #4512

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -50,6 +50,7 @@ keywords: [版本, versions, releases, Spring AI Alibaba, Spring AI 版本适配
             <type>pom</type>
             <scope>import</scope>
         </dependency>
+    </dependencies>
 </dependencyManagement>
 
 <dependencies>


### PR DESCRIPTION
…ment example

Fixes #4512

The versions.md documentation page was missing the </dependencies> closing tag in the dependencyManagement XML example, causing the BOM configuration snippet to be invalid XML.

### Fixes: #[Add issue number here]

### Changes:

### Screenshots of the change:
